### PR TITLE
add workflow for docker on github registry

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,109 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches:
+      - main
+      - feature/docker-github-registry
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag (default: latest)'
+        required: false
+        default: 'latest'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: aihpi/ragsst
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image (test)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  publish:
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    # Only publish from main branch or manual workflow dispatch
+    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ github.event.inputs.tag || 'latest' }}
+            type=sha,prefix={{branch}}-
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            BUILD_DATE=${{ github.event.head_commit.timestamp }}
+            VCS_REF=${{ github.sha }}
+            VERSION=${{ github.event.inputs.tag || 'latest' }}
+
+      - name: Generate image summary
+        run: |
+          echo "### Docker Image Published! 🐳" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Registry:** \`${{ env.REGISTRY }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Tags:**" >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.meta.outputs.tags }}" | sed 's/^/- /' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Platforms:** linux/amd64, linux/arm64" >> $GITHUB_STEP_SUMMARY

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,12 @@ RUN pip install --no-cache-dir uv && \
 COPY app.py ./
 COPY ragsst ./ragsst
 
+# Add metadata labels for GitHub Container Registry
+LABEL org.opencontainers.image.source="https://github.com/aihpi/ragsst"
+LABEL org.opencontainers.image.description="RAGSST - Retrieval Augmented Generation and Semantic-Search Tool"
+LABEL org.opencontainers.image.licenses="GPL-3.0"
+LABEL org.opencontainers.image.documentation="https://github.com/aihpi/ragsst/blob/main/README.md"
+
 # Expose port
 EXPOSE 7860
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,13 @@ services:
 
   # RAGSST App
   ragsst-app:
+      # Use pre-built image from GitHub Container Registry (for workshop participants)
+      image: ghcr.io/aihpi/ragsst:latest
+      # Uncomment the lines below to build locally instead of using pre-built image
+      # build:
+      #   context: ./
+      #   dockerfile: Dockerfile
       container_name: ragsst-app
-      build:
-        context: ./
-        dockerfile: Dockerfile
       ports:
         - "7860:7860"
       volumes:


### PR DESCRIPTION
Add GitHub workflow that builds the Docker container for the app and hosts it on the GitHub package registry. This would save participants' time during workshops and avoid build issues. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Prebuilt multi-arch Docker image (amd64, arm64) now available on GitHub Container Registry for easier deployment.
  - docker-compose now pulls the published image by default for quicker startup.

- Chores
  - Added CI workflow to build, test, tag, and publish Docker images on pushes, PRs, and manual runs.
  - Images include standardized metadata (source, description, license, documentation) for improved registry visibility.
  - Automated tagging supports latest, branch/PR refs, and optional manual tags; publishes a summary of image details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->